### PR TITLE
Use GHz instead of Ghz

### DIFF
--- a/app/web/templates/admin/dashboard.html
+++ b/app/web/templates/admin/dashboard.html
@@ -38,7 +38,7 @@
                 <span class="info-box-number"> {{ round( data['host_stats']['cpu_usage'], 2) }} % </span>
 
                 <span class="progress-description">
-                  {{ round( data['host_stats']['cpu_cur_freq'] / 1000, 2) }} Ghz / {{ round( data['host_stats']['cpu_max_freq'] / 1000, 1) }} Ghz <br/>
+                  {{ round( data['host_stats']['cpu_cur_freq'] / 1000, 2) }} GHz / {{ round( data['host_stats']['cpu_max_freq'] / 1000, 1) }} GHz <br/>
                   <!-- <small>{{ data['host_stats']['cpu_cores'] }} {{ _('threads') }}</small> -->
                 </span>
               </div>

--- a/app/web/templates/ajax/host_cpu_infos.html
+++ b/app/web/templates/ajax/host_cpu_infos.html
@@ -2,6 +2,6 @@
 <span class="info-box-number"> {{ round( data['host_stats']['cpu_usage'], 2) }} % </span>
 
 <span class="progress-description">
-{{ round( data['host_stats']['cpu_cur_freq'] / 1000, 2) }} Ghz / {{ round( data['host_stats']['cpu_max_freq'] / 1000, 1) }} Ghz<br />
+{{ round( data['host_stats']['cpu_cur_freq'] / 1000, 2) }} GHz / {{ round( data['host_stats']['cpu_max_freq'] / 1000, 1) }} GHz<br />
 <!--<small>{{ data['host_stats']['cpu_cores'] }} {{ _('threads') }}</small>-->
 </span>


### PR DESCRIPTION
Gigahertz is using GHz as megahertz is using MHz,
anyway, Hertz is using Hz as it is an SI unit.