### PR TITLE
Update Gitlab URLs due to recent change

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Logins are secure and use the most advanced web security models available.
 - Windows (7,8,10) via a compiled Executable, no need for python installation
 
 ## Installation
-Install documentation is available here on GitLab via the [wiki](https://gitlab.com/Ptarrant1/crafty-web/wikis/Install-Guides).
+Install documentation is available here on GitLab via the [wiki](https://gitlab.com/crafty-controller/crafty-web/wikis/Install-Guides).
 
 ## Documentation
-Check out our shiny new documentation [right on GitLab](https://gitlab.com/Ptarrant1/crafty-web/wikis/home).
+Check out our shiny new documentation [right on GitLab](https://gitlab.com/crafty-controller/crafty-web/wikis/home).
 
 ## Meta
 Phillip Tarrant - [Project Homepage](https://craftycontrol.com/)
@@ -41,4 +41,4 @@ Discord Channel - [Here](https://discord.gg/9VJPhCE)
 
 Trello Board - [Here](https://trello.com/b/wJjAw2s3/crafty)
 
-[GIT Repo](https://gitlab.com/Ptarrant1/crafty-web)
+[GIT Repo](https://gitlab.com/crafty-controller/crafty-web)

--- a/app/classes/helpers.py
+++ b/app/classes/helpers.py
@@ -473,7 +473,7 @@ class helpers:
         return "%.1f%s%s" % (num, 'Y', suffix)
 
     def check_version(self, branch):
-        url = "https://gitlab.com/Ptarrant1/crafty-web/raw/{}/app/config/version.json".format(branch)
+        url = "https://gitlab.com/crafty-controller/crafty-web/raw/{}/app/config/version.json".format(branch)
         try:
             r = requests.get(url, timeout=2)
             if r.status_code == 200:


### PR DESCRIPTION
Previously, it was using URL of maintainer's repository, but it was
moved to crafty-controller.

Fixes issue:
![obrazek](https://user-images.githubusercontent.com/4096468/100125800-798cea80-2e7d-11eb-8d5f-e9bd6a05dcf0.png)
