### PR TITLE
base.html: change behaviour while clicking on logo

### DIFF
--- a/app/web/templates/base.html
+++ b/app/web/templates/base.html
@@ -176,7 +176,7 @@
 
   <aside class="main-sidebar sidebar-dark-primary elevation-4">
     <!-- Logo -->
-    <a href="/" class="brand-link">
+    <a href="/admin/dashboard" class="brand-link">
       <img src="/static/images/crafty.png"
            alt="Crafty Controller Logo" class="brand-image" width="32px" style="width:32px;">
       <span class="brand-text font-weght-light"><b>Crafty</b> Controller</span>


### PR DESCRIPTION
While you are logged as Admin or mod, you don't expect that while
clicking on the logo of Crafty Controller, it logs out you from the UI
and throws you to Crafty Controller Login where you can see server status
and login form. Let's change this behavior to move you to the dashboard.

If you want to be logged out, just click on your Username (user-menu)
and select it there.