### PR TITLE
Automatically Create Server Path & Download Jar

### DIFF
--- a/app/web/templates/admin/dashboard.html
+++ b/app/web/templates/admin/dashboard.html
@@ -240,16 +240,35 @@
                       <label>
                           {{ _('Server Path') }} - <small>{{ _('Example /var/opt/minecraft/server') }}</small>
                         </label>
-                        <input type="text" class="form-control" placeholder="{{ _('Server Path') }}" name="server_path" maxlength="255"
-                              value="/var/opt/minecraft/server">
+                        <input type="text" class="form-control" placeholder="{{ _('/var/opt/minecraft/server') }}" name="server_path" maxlength="255" value="/var/opt/minecraft/server">
                         <span class="glyphicon glyphicon-folder-open form-control-feedback"></span>
+
+                        <div class="form-check">
+                          <input type="checkbox" class="form-check-input" id="create_server_path_checkbox" name="create_server_path" checked>
+                          <label class="form-check-label" for="create_server_path_checkbox">Ensure Path Exists</label>
+                        </div>
                     </div>
 
                     <div class="form-group has-feedback">
                       <label>
-                        {{ _('Server Jar') }} - <small>{{ _('Example paper.jar') }}</small>
+                        {{ _('Server Jar') }} - <small>{{ _('Example server.jar') }}</small>
                       </label>
-                      <input type="text" class="form-control" placeholder="{{ _('Server Jar') }}" name="server_jar" value="paperclip.jar" maxlength="255">
+                      <input type="text" class="form-control" placeholder="{{ _('server.jar') }}" value="server.jar" name="server_jar" maxlength="255">
+                      <span class="glyphicon glyphicon-file form-control-feedback"></span>
+                    </div>
+
+                    <div class="form-group has-feedback">
+                      <label>
+                        {{ _('Server Jar Download (Optional)') }} 
+                        <br />
+                        <small>{{ _('Automatically Download Server Jar from Url') }}</small>
+                        <br />
+                        <small>{{ _('Example: https://example.com/files/server.jar') }}</small>
+                      </label>
+                      <input type="text" class="form-control" placeholder="https://example.com/files/server.jar" name="server_jar_url" value="" maxlength="512">
+                      <small>Vanilla: <a href="https://www.minecraft.net/en-us/download/server" target="_blank">https://www.minecraft.net/en-us/download/server</a></small>
+                      <br />
+                      <small>Paper: <a href="https://papermc.io/downloads" target="_blank">https://papermc.io/downloads</a></small>
                       <span class="glyphicon glyphicon-file form-control-feedback"></span>
                     </div>
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ version: '3'
 services:
   web:
     build: .
+    # Optional (Linux Only): Automatically allows passthrough of required ports. Remove 'ports' section if enabled.
+    # network_mode: host
     ports:
       - "8000:8000"
       - "25500-25600"


### PR DESCRIPTION
- Added a checkbox (checked by default) to automatically create the server path if it doesn't already exist.
- Added server jar URL field to automatically download the server jar (with links to the current vanilla jar, and paper jars)

I added these features to make it easier to quickly create a simple server without needing to access the server via SSH or FTP just to create a folder and upload a jar. 