### PR TITLE
Updated get_world_info to pull world size for worlds with Cubicchunks…

### DIFF
--- a/app/classes/minecraft_server.py
+++ b/app/classes/minecraft_server.py
@@ -649,8 +649,9 @@ class Minecraft_Server():
                 # for each directory we find
                 for name in dirs:
 
-                    # if the directory name is "region"
-                    if name == "region":
+                    # if the directory name is "region" or for servers with Cubic Chunks "region2d" or "region3d"
+                    if name in ("region", "region2d", "region3d"):
+
                         # log it!
                         logger.debug("Path %s is called region. Getting directory size", os.path.join(root, name))
 


### PR DESCRIPTION
… mod installed

Updated get_world_info to allow crafty to get world size info for worlds with cubicchunks installed. Allows crafty to search for the region2d and region3d directories where region files are stored. I tested and verified the update works with a cubicchunks world and crafty displayed the correct world size.