### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND="noninteractive"
 LABEL maintainer="Phillip Tarrant <https://gitlab.com/Ptarrant1> and Dockerfile created by kevdagoat <https://gitlab.com/kevdagoat>"
 
 RUN apt-get update
-RUN apt-get install -y python3 python3-dev python3-pip default-jre libmysqlclient-dev
+RUN apt-get install -y python3 python3-dev python3-pip openjdk-14-jre-headless default-jre libmysqlclient-dev
 
 COPY requirements.txt /crafty_web/requirements.txt
 RUN pip3 install -r /crafty_web/requirements.txt
@@ -17,4 +17,3 @@ EXPOSE 8000
 EXPOSE 25500-25600
 
 CMD ["python3", "crafty.py", "-c", "/crafty_web/configs/docker_config.yml"]
-


### PR DESCRIPTION
newer minecraft versions require Java version 12 or above. added `openjdk-14-jre-headless` to include Java 14. A good feature request would be for the program to automatically switch between Java versions depending on the Minecraft version.